### PR TITLE
make experiment name optional

### DIFF
--- a/lib/Scientist.pm
+++ b/lib/Scientist.pm
@@ -26,7 +26,7 @@ has 'enabled' => (
 has 'experiment' => (
     is       => 'ro',
     isa      => Str,
-    required => 1,
+    builder  => 'name',
 );
 
 has 'use' => (
@@ -43,6 +43,10 @@ has 'try' => (
     is       => 'rw',
     isa      => CodeRef,
 );
+
+sub name {
+    return 'experiment';
+}
 
 sub publish {
     my $self = shift;

--- a/lib/Scientist.pod
+++ b/lib/Scientist.pod
@@ -74,6 +74,8 @@ not be populated.
 
 =item experiment(<STRING>)
 
+DEFAULT : L</Functions/name()>'s output
+
 Simply the name of the experiment included in the result set.
 
 =item publish
@@ -109,6 +111,18 @@ code. The control and candidate code is run in random order.
 Candidate code to be included in the experiment.
 
 This code will be executed and discarded when the experiment is run.
+
+=back
+
+=head1 Functions
+
+=over
+
+=item name(<STRING>)
+
+DEFAULT : 'experiment'
+
+The default string name of the experiment. Intended to be optionally overriden in a subclass.
 
 =back
 


### PR DESCRIPTION
match the behavior in the reference code.

  # The String name of this experiment. Default is "experiment". See
  # Scientist::Default for an example of how to override this default.
  def name
    "experiment"
  end

Currently at https://github.com/github/scientist/blob/master/lib/scientist/experiment.rb#L161