### PR TITLE
Refactor result details

### DIFF
--- a/lib/Scientist.pm
+++ b/lib/Scientist.pm
@@ -1,9 +1,10 @@
 package Scientist;
 
+use Scientist::Result;
 use Moo;
 use Test2::Compare qw/compare strict_convert/;
 use Time::HiRes qw/time/;
-use Types::Standard qw/Bool Str CodeRef HashRef/;
+use Types::Standard qw/Object Bool Str CodeRef HashRef/;
 
 # VERSION
 
@@ -34,7 +35,7 @@ has 'use' => (
 
 has 'result' => (
     is       => 'rw',
-    isa      => HashRef,
+    isa      => Object,
 );
 
 has 'try' => (
@@ -102,7 +103,7 @@ sub run {
         diagnostic => $diag,
     };
 
-    $self->result( \%result );
+    $self->result( Scientist::Result->new(\%result) );
     $self->publish;
 
     return $wantarray ? @control : $control[0];

--- a/lib/Scientist.pod
+++ b/lib/Scientist.pod
@@ -95,7 +95,7 @@ NB: This code is run and returned even if the experiment's C<enabled=false>.
 
 =item result()
 
-Result contains the result of the experiment after it is run.
+Result contains the result of the experiment after it is run as object of type L<Scientist::Result>.
 
 Will contain data only AFTER C<-E<gt>run()> has been called.
 
@@ -149,15 +149,21 @@ Below is a small example that pushes mismatch info and timings to StatsD:
   sub publish {
     my $self = shift;
 
-    my $experiment = $self->result->{experiment};
+    my $result = $self->result;
+    my $experiment = $result->experiment;
+
     # Increment counter for every match or mismatch
-    Net::Statsd::increment("$experiment.mismatch") if $self->result->{mismatched};
-    Net::Statsd::increment("$experiment.match") unless $self->result->{mismatched};
+    if ($result->mismatched) {
+        Net::Statsd::increment("$experiment.mismatch");
+    }
+    else {
+        Net::Statsd::increment("$experiment.match");
+    }
 
     # Log timings (converting Scientist microsends to StatsD miliseconds)
     # Note: This implementation rounds down the duration.
-    Net::Statsd::timing("$experiment.control",   int $self->result->{control}{duration} * 1_000);
-    Net::Statsd::timing("$experiment.candidate", int $self->result->{candidate}{duration} * 1_000);
+    Net::Statsd::timing("$experiment.control",   int $result->control->duration * 1_000);
+    Net::Statsd::timing("$experiment.candidate", int $result->candidate->duration * 1_000);
   }
 
   1;

--- a/lib/Scientist.pod
+++ b/lib/Scientist.pod
@@ -38,11 +38,11 @@ Perl module inspired by https://github.com/github/scientist ( http://githubengin
 
   say "The number ten is $answer";
   warn 'There was a mismatch between control and candidate'
-    if $experiment->result->{'mismatched'};
+    if $experiment->result->mismatched;
 
   say 'Timings:';
-  say 'Control code:   ', $experiment->result->{control}{duration}, ' microseconds';
-  say 'Candidate code: ', $experiment->result->{candidate}{duration}, ' microseconds';
+  say 'Control code:   ', $experiment->result->control->duration, ' microseconds';
+  say 'Candidate code: ', $experiment->result->candidate->duration, ' microseconds';
 
 =head1 Introduction
 

--- a/lib/Scientist/Player.pm
+++ b/lib/Scientist/Player.pm
@@ -1,0 +1,46 @@
+package Scientist::Player;
+
+use Moo;
+
+# VERSION
+
+has 'duration' => (is => 'ro');
+
+1;
+
+=head1 NAME
+
+Scientist::Player - Represent the player result.
+
+=head1 METHODS
+
+=head2 duration()
+
+Returns the duration.
+
+=head1 LICENSE
+
+This software is Copyright (c) 2016 by Lance Wicks.
+
+This is free software, licensed under:
+
+  The MIT (X11) License
+
+The MIT License
+
+Permission is hereby  granted, free of charge, to  any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR  OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/Scientist/Result.pm
+++ b/lib/Scientist/Result.pm
@@ -1,0 +1,98 @@
+package Scientist::Result;
+
+use Scientist::Player;
+use Moo;
+use Types::Standard qw/Bool Object Str/;
+
+# VERSION
+
+has 'context'     => (is => 'ro');
+has 'observation' => (is => 'ro');
+has 'experiment'  => (is => 'ro', isa => Str);
+has 'candidate'   => (is => 'ro', isa => Object);
+has 'control'     => (is => 'ro', isa => Object);
+has 'matched'     => (is => 'ro', isa => Bool);
+has 'mismatched'  => (is => 'ro', isa => Bool);
+
+around BUILDARGS => sub {
+    my ($orig, $class, $args) = @_;
+
+    foreach my $key (qw(control candidate)) {
+        if (exists $args->{$key}) {
+            $args->{$key} = Scientist::Player->new($args->{$key});
+        }
+    }
+
+    return $class->$orig($args);
+};
+
+1;
+
+=head1 NAME
+
+Scientist::Result - Represent the test result.
+
+=head1 DESCRIPTION
+
+The user can make use of the object C<Scientist::Result> in their own method C<publish()>.
+
+=head1 METHODS
+
+=head2 BUILDARGS()
+
+B<FOR INTERNAL USE ONLY>
+
+=head2 context()
+
+Returns the context of the run.
+
+=head2 observation()
+
+Returns the observation of the run.
+
+=head2 experiment()
+
+Returns the experiment details.
+
+=head2 candidate()
+
+Returns object of type L<Scientist::Player>.
+
+=head2 control()
+
+Returns object of type L<Scientist::Player>.
+
+=head2 matched()
+
+Returns matched count.
+
+=head2 mismatched()
+
+Returns mismatched count.
+
+=head1 LICENSE
+
+This software is Copyright (c) 2016 by Lance Wicks.
+
+This is free software, licensed under:
+
+  The MIT (X11) License
+
+The MIT License
+
+Permission is hereby  granted, free of charge, to  any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR  OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Hi @lancew 

Please review the PR.
Little background about the PR, the objective is to hide the internals of 'result' and present the end user, a very simple interface to work with. I have introduced two packages:
1) Scientist::Result
2) Scientist::Player

The package Scientist::Result will hold the existing result structure unchanged. So it is backward compatible, yet provide nice simple interface. The package Scientist::Player simply hold existing 'control' and 'candidate'. 

Please take a look the updated pod how the end result would look like.

Feel free to dump if it doesn't fit in your preferred design architecture.
If it does get merged then I will provide unit test for the new packages in the next PR.

Many Thanks.
Best Regards,
Mohammad S Anwar

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lancew/scientist/34)
<!-- Reviewable:end -->
