### PR TITLE
Proposed fix the error when running the SYNOPSIS code.

### DIFF
--- a/lib/Scientist.pm
+++ b/lib/Scientist.pm
@@ -3,6 +3,7 @@ package Scientist;
 
 use Moo;
 use Test2::Compare v0.0.121 qw/compare strict_convert/;
+use Test2::Compare::Delta;
 use Time::HiRes qw/time/;
 use Types::Standard qw/Bool Str CodeRef HashRef/;
 


### PR DESCRIPTION
Hi @lancew,

Please review the pull request.
It just explicitly import Test2::Compare::Delta as I am getting error as below when running the code from SYNOPSIS.
    
       Can't locate object method "set_column_alias" via package "Test2::Compare::Delta" 
       (perhaps you forgot to load Test2::Compare::Delta"?)

Many Thanks.

Best Regards,
Mohammad